### PR TITLE
Revamp root certificate authority logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ geolite_ip_data/
 venv/
 __pycache__/
 *.txt
+feedback.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@ geolite_ip_data/
 .idea/
 venv/
 __pycache__/
-*.txt
 feedback.txt
+log.txt
+output.txt
+domain_inputs.txt
+.venv/
+GeoLite2-City_20250425/
+GeoLite2-Country_20250425/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#SecurityAuditTool
+##SecurityAuditTool
 
 ## Description
 
@@ -70,7 +70,7 @@ curl -X POST "http://localhost:8000/audit"   -H "accept: text/plain"   -H "Conte
 6) Insecure HTTP - Boolean denoting whether domain name supports HTTP calls. Considered True even when HTTP calls are redirected to HTTPs
 7) Redirect to HTTPS -  Boolean denoting whether HTTP calls are redirected to HTTPs within 10 redirects.
 8) RTT Range  - A range of decimals denoting the minimum and maximum round trip time in seconds among all IPv4 addresses and ports: (443, 80, 20) combination associated with the domain.
-9) Root CA Name - The name of Root Certificate along the chain of certificates associated with the certificate of the domain.
+9) Root CA Name - The name of Root Certificate Authority along the chain of certificates associated with the certificate of the domain.
 10) Reverse DNS - A list of reverse DNS values for each IPv4 address associated with the domain. 
 11) Geolocation of IPs - A list of geolocations associated with the IPv4 addresses associated with the domain.
 12) Domain Enforces Strict Transport - Boolean denoting whether the domain enforces browser to shift any HTTP call to HTTPS. Works by checking the presence of `hsts` header.
@@ -88,4 +88,4 @@ If you want to contribute to this project, please follow these steps:
 Specify the project's license here. For example:
 
 This project is licensed under the MIT License. See the `LICENSE` file for details.
->>>>>>> 1d1db76 (Security Audit Tool full work)
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##SecurityAuditTool
+## SecurityAuditTool
 
 ## Description
 
@@ -14,17 +14,25 @@ Make sure you satisfy the following:
 - Python 3.12.10 installed
 - The following Python packages:
     - `pip`
+- Modules specified in requirements.txt available to scan.py and server.py
+  - Command for installation
+  ```bash
+    pip install -r requirements.txt
+  ```
 - scan.py should run in a POSIX compliant OS with utilities such as nslookup and openssl installed.
 - Availability of MaxMind GeoLite2 City database file within a subdirectory named geolite_ip_data inside the running directory of scan.py
   - To download it manually, download it from https://dev.maxmind.com/geoip/geolite2/ using your own MaxMind license key.
   - Ensure you place the downloaded file in geolite_ip_data subdirectory inside the running directory of scan.py.
+- System level dependencies:
+This project requires a few system-level packages to function correctly. These are not installed via `pip`.
 
-You can install required packages using pip:
+Install them with:
 
 ```bash
-pip install -r requirements.txt
+sudo apt update && sudo apt install -y \
+    libssl-dev build-essential python3-dev pkg-config ca-certificates
+
 ```
-  
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742a3#egg=oscrypto
+certifi==2025.1.31
+certvalidator==0.11.1
+cryptography==45.0.3
+dnspython==2.7.0
+fastapi==0.115.12
+geoip2==5.0.1
+maxminddb==2.6.3
+pyOpenSSL==25.1.0
+Requests==2.32.3
+texttable==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742a3#egg=oscrypto
-certifi==2025.1.31
+certifi==2025.4.26
 certvalidator==0.11.1
 cryptography==45.0.3
 dnspython==2.7.0

--- a/scan.py
+++ b/scan.py
@@ -201,6 +201,8 @@ def get_root_ca(domain_name) -> str :
     intermediates = server_certs[1:]
 
     trust_roots = load_trust_roots()
+    # TODO - opencrpyto has a bug in it's version detection
+    # We would need to download from master rather than pip because this has not been released
     context = ValidationContext(trust_roots=trust_roots, allow_fetching=True)
     validator = CertificateValidator(leaf, intermediates, validation_context=context)
     path = validator.validate_usage(extended_key_usage=set(['server_auth']))

--- a/scan.py
+++ b/scan.py
@@ -199,10 +199,10 @@ def rtt_range(domain_name):
     return [mn, mx]
 
 
-def get_root_ca(domain_name) -> str:
+def get_root_ca(domain_name) -> str|None:
     """
     :param domain_name: The domain of which the root certificate authority is asked
-    :return: A string denoting the root certificate authority
+    :return: A string denoting the root certificate authority. Returns None when an error occured
     """
     global error_logs
     try:
@@ -227,6 +227,12 @@ def get_root_ca(domain_name) -> str:
 
 
 def get_cert_chain_from_server(domain_name, port=HTTPS_PORT) -> list[bytes]:
+    """
+    :param domain_name: The domain_name of whom to request certificate chain from.
+    :param port: The port to use for the connection. Defaults TO HTTPS_PORT and specifying a different port
+                 comes at a risk of the domain_name rejecting the connection request
+    :return: A list of PEM encoded byte strings denoting the certificate chain obtained from the domain_name
+    """
     ctx = SSL.Context(SSL.TLS_CLIENT_METHOD)
     ctx.set_verify(SSL.VERIFY_NONE, lambda *args: True)
 
@@ -244,6 +250,10 @@ def get_cert_chain_from_server(domain_name, port=HTTPS_PORT) -> list[bytes]:
 
 
 def load_trust_roots() -> list[bytes]:
+    """
+    Returns the trusted root certificates from certifi store which is Mozilla's carefully curated collection of Root Certificates
+    :return: A list of PEM encoded byte strings denoting the root certificates obtained from the certificate store.
+    """
     with open(certifi.where(), 'rb') as f:
         pem_data = f.read()
     root_certificates = x509.load_pem_x509_certificates(pem_data)

--- a/scan.py
+++ b/scan.py
@@ -201,8 +201,6 @@ def get_root_ca(domain_name) -> str :
     intermediates = server_certs[1:]
 
     trust_roots = load_trust_roots()
-    # TODO - opencrpyto has a bug in it's version detection
-    # We would need to download from master rather than pip because this has not been released
     context = ValidationContext(trust_roots=trust_roots, allow_fetching=True)
     validator = CertificateValidator(leaf, intermediates, validation_context=context)
     path = validator.validate_usage(extended_key_usage=set(['server_auth']))

--- a/scan.py
+++ b/scan.py
@@ -24,7 +24,8 @@ import certifi
 from certvalidator import CertificateValidator, ValidationContext
 
 error_logs = ""
-HTTPS_PORT=443
+HTTPS_PORT = 443
+
 
 def run_command_and_get_result(command):
     """
@@ -56,7 +57,7 @@ def get_ip_addresses(domain_name, address_format):
             return None
         return get_addresses_from_nslookup_output(nslookup_result)
     except TimeoutExpired:
-        error_logs += "nslookup timed out while fetching IPs for " + domain_name +"\n"
+        error_logs += "nslookup timed out while fetching IPs for " + domain_name + "\n"
         return None
     except ValueError:
         error_logs += "Error while parsing nslookup output for " + domain_name + " " + address_format + " IPs\n"
@@ -64,6 +65,7 @@ def get_ip_addresses(domain_name, address_format):
     except CalledProcessError:
         error_logs += "Error while executing nslookup for " + domain_name + " " + address_format + " IPs\n"
         return None
+
 
 def is_valid_ipaddr(address):
     """
@@ -75,6 +77,7 @@ def is_valid_ipaddr(address):
         return True
     except ValueError:
         return False
+
 
 def get_addresses_from_nslookup_output(result):
     """
@@ -93,8 +96,8 @@ def get_addresses_from_nslookup_output(result):
     :raises ValueError: If the string does not seem to match one of the format.
     """
     prefix_not_having_ips, suffix_having_ips = result.split('Name:', maxsplit=1)
-    addresses=[]
-    while len(suffix_having_ips)>0:
+    addresses = []
+    while len(suffix_having_ips) > 0:
         current_line, suffix_having_ips = suffix_having_ips.split('\n', maxsplit=1)
         if "Address" in current_line:
             ip_address = re.split("Addresses:|Address:", current_line)[1].strip()
@@ -104,18 +107,21 @@ def get_addresses_from_nslookup_output(result):
                 ip_address = current_line.strip()
                 addresses.append(ip_address)
     return addresses
+
+
 def http_server(domain_name):
     """
     :param domain_name: The domain name of the server to query.
     :return: The server type obtained from the "server" header of the HTTPS response, or None if the header is not present or an error occurs.
     """
     try:
-        response = requests.request("GET", "https://"+domain_name, timeout=2)
+        response = requests.request("GET", "https://" + domain_name, timeout=2)
         return response.headers["server"] if "server" in response.headers else None
     except RequestException:
         global error_logs
-        error_logs += "Unable to make a HTTPS GET request to " + domain_name +" for determining it's server\n"
+        error_logs += "Unable to make a HTTPS GET request to " + domain_name + " for determining it's server\n"
         return None
+
 
 def listens_for_insecure_connections(domain_name):
     """
@@ -123,12 +129,13 @@ def listens_for_insecure_connections(domain_name):
     :return: True if the domain listens for insecure connections and the HTTP request is successful; False if the http request is unsuccesful; None if an exception occurs during the request.
     """
     try:
-        response = requests.request("GET", "http://"+domain_name, timeout=2)
+        response = requests.request("GET", "http://" + domain_name, timeout=2)
         return response.ok
     except RequestException:
         global error_logs
-        error_logs += "Unable to make a HTTP GET request to " + domain_name +" for determining whether it listens for insecure requests\n"
+        error_logs += "Unable to make a HTTP GET request to " + domain_name + " for determining whether it listens for insecure requests\n"
         return None
+
 
 def insecure_connection_redirects_to_secure(domain_name):
     """
@@ -140,31 +147,33 @@ def insecure_connection_redirects_to_secure(domain_name):
     """
     response = None
     try:
-        response = requests.get("http://"+domain_name, allow_redirects=False, timeout=2)
+        response = requests.get("http://" + domain_name, allow_redirects=False, timeout=2)
         redirect_limit = 10
-        while redirect_limit>0:
+        while redirect_limit > 0:
             if 400 > response.status_code >= 300:
                 if response.headers["Location"].startswith("https"):
                     return True
                 else:
                     response = requests.get(response.headers["Location"], allow_redirects=False)
-                    redirect_limit-=1
+                    redirect_limit -= 1
             else:
                 return False
         return False
     except RequestException:
         global error_logs
         if isinstance(response, Response):
-            error_logs += "Unable to make a HTTP GET request to " + response.headers["Location"] +" for determining whether it listens for insecure requests\n"
-        else :
-            error_logs += "Unable to make a HTTP GET request to " + domain_name +" for determining whether it listens for insecure requests\n"
+            error_logs += "Unable to make a HTTP GET request to " + response.headers[
+                "Location"] + " for determining whether it listens for insecure requests\n"
+        else:
+            error_logs += "Unable to make a HTTP GET request to " + domain_name + " for determining whether it listens for insecure requests\n"
         return None
+
 
 def rtt_range(domain_name):
     # for each of ivp4 addresses, create a socket.socket
     ivp4_addresses = get_ip_addresses(domain_name, "ivp4")
     mn = math.inf
-    mx= -math.inf
+    mx = -math.inf
     global error_logs
     if ivp4_addresses is not None:
         for ivp4_address in ivp4_addresses:
@@ -181,30 +190,41 @@ def rtt_range(domain_name):
                     sock.close()
                     break
                 except TimeoutError:
-                    error_logs+="TCP connection request for rtt calculation timed out for " + domain_name + " on port:"+ str(port) + " " + "timed out.\n"
+                    error_logs += "TCP connection request for rtt calculation timed out for " + domain_name + " on port:" + str(
+                        port) + " " + "timed out.\n"
                     continue
     if mn == math.inf and mx == -math.inf:
-        error_logs+="RTT variance calculation failed as TCP connection from multiple ports " + domain_name + " timed out.\n"
+        error_logs += "RTT variance calculation failed as TCP connection from multiple ports " + domain_name + " timed out.\n"
         return None
     return [mn, mx]
-# TODO - Add modularization here instead of having all
-def get_root_ca(domain_name) -> str :
+
+
+def get_root_ca(domain_name) -> str:
     """
     :param domain_name: The domain of which the root certificate authority is asked
     :return: A string denoting the root certificate authority
     """
-    server_certs = get_cert_chain_from_server(domain_name)
-    if not server_certs:
-        raise Exception("No certificates retrieved from server.")
+    global error_logs
+    try:
+        server_certs = get_cert_chain_from_server(domain_name)
+        if not server_certs:
+            raise Exception("No certificates retrieved from server.")
 
-    leaf = server_certs[0]
-    intermediates = server_certs[1:]
+        leaf = server_certs[0]
+        intermediates = server_certs[1:]
 
-    trust_roots = load_trust_roots()
-    context = ValidationContext(trust_roots=trust_roots, allow_fetching=True)
-    validator = CertificateValidator(leaf, intermediates, validation_context=context)
-    path = validator.validate_usage(extended_key_usage=set(['server_auth']))
-    return path.first.subject.human_friendly
+        trust_roots = load_trust_roots()
+        if not trust_roots:
+            raise Exception("Error loading root certificates")
+        # TODO-allow_fetching:False is less secure since we would not check whether is certificate has been revoked
+        context = ValidationContext(trust_roots=trust_roots, allow_fetching=False)
+        validator = CertificateValidator(leaf, intermediates, validation_context=context)
+        path = validator.validate_usage(key_usage=set(), extended_key_usage=set(['server_auth']))
+        return path.first.subject.human_friendly
+    except Exception as e:
+        error_logs += "Something went wrong while getting root certificate authority for " + domain_name
+        return None
+
 
 def get_cert_chain_from_server(domain_name, port=HTTPS_PORT) -> list[bytes]:
     ctx = SSL.Context(SSL.TLS_CLIENT_METHOD)
@@ -222,6 +242,7 @@ def get_cert_chain_from_server(domain_name, port=HTTPS_PORT) -> list[bytes]:
         pem_encoded_certs.append(cert.public_bytes(serialization.Encoding.PEM))
     return pem_encoded_certs
 
+
 def load_trust_roots() -> list[bytes]:
     with open(certifi.where(), 'rb') as f:
         pem_data = f.read()
@@ -231,20 +252,23 @@ def load_trust_roots() -> list[bytes]:
         pem_encoded_root_certificates.append(cert.public_bytes(serialization.Encoding.PEM))
     return pem_encoded_root_certificates
 
+
 def reverse_dns(domain_name):
     ivp4_addresses = get_ip_addresses(domain_name, "ivp4")
     dns_resolver_address = "1.1.1.1"
     global error_logs
     for ivp4_address in ivp4_addresses:
         try:
-            responses = dns.resolver.resolve_at(dns_resolver_address, ipaddress.ip_address(ivp4_address).reverse_pointer, dns.rdatatype.PTR)
+            responses = dns.resolver.resolve_at(dns_resolver_address,
+                                                ipaddress.ip_address(ivp4_address).reverse_pointer, dns.rdatatype.PTR)
             return list(map(lambda response: response.target.to_unicode(), responses))
         except Exception as e:
-            error_logs += "While finding reverse dns entries for " + domain_name + " ip:" + ivp4_address + ", the following error was hit:" + str(e)+"\n"
+            error_logs += "While finding reverse dns entries for " + domain_name + " ip:" + ivp4_address + ", the following error was hit:" + str(
+                e) + "\n"
             return None
 
-def get_geolocation_of_ips(domain_name):
 
+def get_geolocation_of_ips(domain_name):
     global error_logs
     ivp4_addresses = get_ip_addresses(domain_name, "ivp4")
     geolocations = set()
@@ -253,7 +277,7 @@ def get_geolocation_of_ips(domain_name):
             try:
                 response = reader.city(ivp4_address)
                 if response.city.name is not None and response.country.name is not None:
-                    geolocations.add(response.city.name+", "+response.country.name)
+                    geolocations.add(response.city.name + ", " + response.country.name)
                 elif response.city.name is not None:
                     geolocations.add(response.city.name)
                 elif response.country.name is not None:
@@ -268,28 +292,29 @@ def get_geolocation_of_ips(domain_name):
 
 def domain_enforces_strict_transport(domain_name):
     try:
-        response = requests.request("GET", "https://"+domain_name, timeout=2)
+        response = requests.request("GET", "https://" + domain_name, timeout=2)
         if "hsts" in response.headers:
             return True if response.headers["hsts"] == "true" else False
         else:
             return False
     except RequestException:
         global error_logs
-        error_logs += "Unable to make a HTTPS GET request to " + domain_name +" for determining hsts header\n"
+        error_logs += "Unable to make a HTTPS GET request to " + domain_name + " for determining hsts header\n"
         return None
+
 
 def get_domain_security_stats(domain_name):
     return {
-        "scan_time" : int(time.time()),
+        "scan_time": int(time.time()),
         "ipv4_addresses": get_ip_addresses(domain_name, "ivp4"),
         "ivp6_addresses": get_ip_addresses(domain_name, "ivp6"),
         "http_server": http_server(domain_name),
         "insecure_http": listens_for_insecure_connections(domain_name),
-        "redirect_to_https":insecure_connection_redirects_to_secure(domain_name),
-        "rtt_range":rtt_range(domain_name),
-        "root_ca_name":get_root_ca(domain_name),
-        "rdns" : reverse_dns(domain_name),
-        "geolocation_of_ips" : get_geolocation_of_ips(domain_name),
+        "redirect_to_https": insecure_connection_redirects_to_secure(domain_name),
+        "rtt_range": rtt_range(domain_name),
+        "root_ca_name": get_root_ca(domain_name),
+        "rdns": reverse_dns(domain_name),
+        "geolocation_of_ips": get_geolocation_of_ips(domain_name),
         "domain_enforces_strict_transport": domain_enforces_strict_transport(domain_name),
     }
 
@@ -302,46 +327,48 @@ def create_report_text(domain_security_stats):
     """
     table = texttable.Texttable()
     label_names_and_col_nums = {
-        "domain_name" : ("Domain Name", 0),
-        "scan_time" : ("Scan Time", 1),
-        "ipv4_addresses" : ("IPv4 Addresses", 2),
-        "ivp6_addresses" : ("IPv6 Addresses", 3),
-        "http_server" : ("HTTP Server", 4),
-        "insecure_http" : ("Insecure HTTP", 5),
-        "redirect_to_https" : ("Redirect to HTTPS", 6),
-        "rtt_range" : ("RTT Range", 7),
-        "root_ca_name" : ("Root CA Name", 8),
-        "rdns" : ("Reverse DNS", 9),
-        "geolocation_of_ips" : ("Geolocation of IPs", 10),
+        "domain_name": ("Domain Name", 0),
+        "scan_time": ("Scan Time", 1),
+        "ipv4_addresses": ("IPv4 Addresses", 2),
+        "ivp6_addresses": ("IPv6 Addresses", 3),
+        "http_server": ("HTTP Server", 4),
+        "insecure_http": ("Insecure HTTP", 5),
+        "redirect_to_https": ("Redirect to HTTPS", 6),
+        "rtt_range": ("RTT Range", 7),
+        "root_ca_name": ("Root CA Name", 8),
+        "rdns": ("Reverse DNS", 9),
+        "geolocation_of_ips": ("Geolocation of IPs", 10),
         "domain_enforces_strict_transport": ("Domain Enforces Strict Transport", 11),
     }
     num_cols = 12
-    header_row = [None]*num_cols
-    cols_width = [15]*num_cols
+    header_row = [None] * num_cols
+    cols_width = [15] * num_cols
     table.set_cols_width(cols_width)
     for label, col_num in label_names_and_col_nums.values():
         header_row[col_num] = label
     table.header(header_row)
     for domain_name, security_stats in domain_security_stats.items():
-        row = [None]*num_cols
+        row = [None] * num_cols
         row[0] = domain_name
         for stat_identifier, stat_value in security_stats.items():
-            col_num_for_stat=label_names_and_col_nums[stat_identifier][1]
+            col_num_for_stat = label_names_and_col_nums[stat_identifier][1]
             row[col_num_for_stat] = "N/A" if stat_value is None else str(stat_value)
         table.add_row(row)
     return table.draw()
 
+
 def generate_security_report_text(domain_file_content):
-    domain_names=[]
+    domain_names = []
     for line in domain_file_content.splitlines():
         line_trimmed = line.rstrip()
         if len(line_trimmed) > 0:
             domain_names.append(line_trimmed)
 
-    domain_stats=dict()
+    domain_stats = dict()
     for domain_name in domain_names:
-        domain_stats[domain_name]=get_domain_security_stats(domain_name)
+        domain_stats[domain_name] = get_domain_security_stats(domain_name)
     return create_report_text(domain_stats)
+
 
 def go():
     parser = argparse.ArgumentParser()
@@ -361,6 +388,7 @@ def go():
             if error_logs.strip():
                 error_log_file.write(error_logs)
 
+
 if os.name != "posix":
     raise Exception("scan.py does not support non-posix operating systems")
 
@@ -369,8 +397,8 @@ for command in ["nslookup", "openssl"]:
     if shutil.which(command) is None:
         missing_commands.append(command)
 
-if len(missing_commands)>0:
-        raise Exception("Missing command(s) ".join(missing_commands))
+if len(missing_commands) > 0:
+    raise Exception("Missing command(s) ".join(missing_commands))
 
 if __name__ == "__main__":
     go()


### PR DESCRIPTION
Revamp how root certificate organization name is inferred by making use of Python libraries rather than parsing command line output, add requirements.txt and, update documentation