### PR TITLE
Refactor logging methodology to use Logging modules, add more context in logs, and give users ability to control log levels

### DIFF
--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ app = FastAPI()
 @app.post("/audit")
 async def audit_file(file: UploadFile = File(...)):
     contents = await file.read()
-    result_str = scan.generate_security_report_text(contents.decode("utf-8"))
+    result_str = scan.output_domain_stats_module_mode(contents.decode("utf-8"))
     result_io = io.BytesIO(result_str.encode("utf-8"))
     return StreamingResponse(result_io, media_type="text/plain", headers={
         "Content-Disposition": f"attachment; filename=report.txt"


### PR DESCRIPTION

1) Give stack trace context in logs. For addresses, give readers the information that IP addresses fetch failed for a domain as part of RTT time calculation. 3) Remove global string variable which as it would have race conditions if the server code is adjusted to run each request in a thread, which is a anticipated move. 4) Give command line users the ability to control the log level, if they want logging. 5) Give a session_id in the logs for each call of domain stats. 6) Adjust RTT calculation to average RTT across IPV4/IPV6 addresses rather than just IPV4